### PR TITLE
Pull in changes from gnuradio v3.7.9.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ message(STATUS "Build type set to ${CMAKE_BUILD_TYPE}.")
 set(VERSION_INFO_MAJOR_VERSION 3)
 set(VERSION_INFO_API_COMPAT    7)
 set(VERSION_INFO_MINOR_VERSION 9)
-set(VERSION_INFO_MAINT_VERSION 0)
+set(VERSION_INFO_MAINT_VERSION 1)
 include(GrVersion) #setup version info
 
 # Append -O2 optimization flag for Debug builds

--- a/gnuradio-runtime/include/gnuradio/sptr_magic.h
+++ b/gnuradio-runtime/include/gnuradio/sptr_magic.h
@@ -38,6 +38,7 @@ namespace gnuradio {
     public:
       static boost::shared_ptr<gr::basic_block> fetch_initial_sptr(gr::basic_block *p);
       static void create_and_stash_initial_sptr(gr::hier_block2 *p);
+      static void cancel_initial_sptr(gr::hier_block2 *p);
     };
   };
 

--- a/gnuradio-runtime/lib/block_executor.cc
+++ b/gnuradio-runtime/lib/block_executor.cc
@@ -370,11 +370,24 @@ namespace gr {
       // ask the block how much input they need to produce noutput_items
       m->forecast (noutput_items, d_ninput_items_required);
 
-      // See if we've got sufficient input available
+      // See if we've got sufficient input available and make sure we
+      // didn't overflow on the input.
       int i;
-      for(i = 0; i < d->ninputs (); i++)
+      for(i = 0; i < d->ninputs (); i++) {
         if(d_ninput_items_required[i] > d_ninput_items[i])	// not enough
           break;
+
+        if(d_ninput_items_required[i] < 0) {
+          std::cerr << "\nsched: <block " << m->name()
+                    << " (" << m->unique_id() << ")>"
+                    << " thinks its ninput_items required is "
+                    << d_ninput_items_required[i]
+                    << " and cannot be negative.\n"
+                    << "Some parameterization is wrong. "
+                    << "Too large a decimation value?\n\n";
+          goto were_done;
+        }
+      }
 
       if(i < d->ninputs()) {			// not enough input on input[i]
         // if we can, try reducing the size of our output request

--- a/gnuradio-runtime/lib/buffer.cc
+++ b/gnuradio-runtime/lib/buffer.cc
@@ -347,8 +347,8 @@ namespace gr {
     gr::thread::scoped_lock guard(*mutex());
 
     v.resize(0);
-    std::multimap<uint64_t,tag_t>::iterator itr = d_buffer->get_tags_lower_bound(abs_start);
-    std::multimap<uint64_t,tag_t>::iterator itr_end   = d_buffer->get_tags_upper_bound(abs_end);
+    std::multimap<uint64_t,tag_t>::iterator itr = d_buffer->get_tags_lower_bound(std::min(abs_start, abs_start - d_attr_delay));
+    std::multimap<uint64_t,tag_t>::iterator itr_end = d_buffer->get_tags_upper_bound(std::min(abs_end, abs_end - d_attr_delay));
 
     uint64_t item_time;
     while(itr != itr_end) {

--- a/gnuradio-runtime/lib/flat_flowgraph.cc
+++ b/gnuradio-runtime/lib/flat_flowgraph.cc
@@ -324,7 +324,7 @@ namespace gr {
       //std::cerr << "reader: " << r << "  alignment: " << ri << std::endl;
       if(ri != 0) {
         size_t itemsize = block->detail()->input(i)->get_sizeof_item();
-        block->detail()->input(i)->update_read_pointer(alignment-ri/itemsize);
+        block->detail()->input(i)->update_read_pointer((alignment-ri)/itemsize);
       }
       block->set_unaligned(0);
       block->set_is_unaligned(false);
@@ -336,7 +336,7 @@ namespace gr {
       //std::cerr << "writer: " << w << "  alignment: " << wi << std::endl;
       if(wi != 0) {
         size_t itemsize = block->detail()->output(i)->get_sizeof_item();
-        block->detail()->output(i)->update_write_pointer(alignment-wi/itemsize);
+        block->detail()->output(i)->update_write_pointer((alignment-wi)/itemsize);
       }
       block->set_unaligned(0);
       block->set_is_unaligned(false);

--- a/gnuradio-runtime/lib/hier_block2.cc
+++ b/gnuradio-runtime/lib/hier_block2.cc
@@ -57,6 +57,8 @@ namespace gr {
 
   hier_block2::~hier_block2()
   {
+    disconnect_all();
+    gnuradio::detail::sptr_magic::cancel_initial_sptr(this);
     delete d_detail;
   }
 

--- a/gnuradio-runtime/lib/hier_block2_detail.cc
+++ b/gnuradio-runtime/lib/hier_block2_detail.cc
@@ -328,10 +328,44 @@ namespace gr {
   }
 
   void
+  hier_block2_detail::refresh_io_signature()
+  {
+    int min_inputs  = d_owner->input_signature()->min_streams();
+    int max_inputs  = d_owner->input_signature()->max_streams();
+    int min_outputs = d_owner->output_signature()->min_streams();
+    int max_outputs = d_owner->output_signature()->max_streams();
+
+    if(max_inputs == io_signature::IO_INFINITE ||
+       max_outputs == io_signature::IO_INFINITE ||
+       (min_inputs != max_inputs) ||(min_outputs != max_outputs) ) {
+      std::stringstream msg;
+      msg << "Hierarchical blocks do not yet support arbitrary or"
+        << " variable numbers of inputs or outputs (" << d_owner->name() << ")";
+      throw std::runtime_error(msg.str());
+    }
+
+    // Check for # input change
+    if ((signed)d_inputs.size() != max_inputs)
+    {
+      d_inputs.resize(max_inputs);
+    }
+
+    // Check for # output change
+    if ((signed)d_outputs.size() != max_outputs)
+    {
+      d_outputs.resize(max_outputs);
+      d_min_output_buffer.resize(max_outputs, 0);
+      d_max_output_buffer.resize(max_outputs, 0);
+    }
+  }
+
+  void
   hier_block2_detail::connect_input(int my_port, int port,
                                     basic_block_sptr block)
   {
     std::stringstream msg;
+
+    refresh_io_signature();
 
     if(my_port < 0 || my_port >= (signed)d_inputs.size()) {
       msg << "input port " << my_port << " out of range for " << block;
@@ -356,6 +390,8 @@ namespace gr {
   {
     std::stringstream msg;
 
+    refresh_io_signature();
+
     if(my_port < 0 || my_port >= (signed)d_outputs.size()) {
       msg << "output port " << my_port << " out of range for " << block;
       throw std::invalid_argument(msg.str());
@@ -375,6 +411,8 @@ namespace gr {
                                        basic_block_sptr block)
   {
     std::stringstream msg;
+
+    refresh_io_signature();
 
     if(my_port < 0 || my_port >= (signed)d_inputs.size()) {
       msg << "input port number " << my_port << " out of range for " << block;
@@ -398,6 +436,8 @@ namespace gr {
                                         basic_block_sptr block)
   {
     std::stringstream msg;
+
+    refresh_io_signature();
 
     if(my_port < 0 || my_port >= (signed)d_outputs.size()) {
       msg << "output port number " << my_port << " out of range for " << block;

--- a/gnuradio-runtime/lib/hier_block2_detail.h
+++ b/gnuradio-runtime/lib/hier_block2_detail.h
@@ -71,6 +71,7 @@ namespace gr {
     endpoint_vector_t d_outputs;             // Single internal endpoint per external output
     basic_block_vector_t d_blocks;
 
+    void refresh_io_signature();
     void connect_input(int my_port, int port, basic_block_sptr block);
     void connect_output(int my_port, int port, basic_block_sptr block);
     void disconnect_input(int my_port, int port, basic_block_sptr block);

--- a/gnuradio-runtime/python/gnuradio/gru/freqz.py
+++ b/gnuradio-runtime/python/gnuradio/gru/freqz.py
@@ -101,7 +101,7 @@ def polyval(p,x):
         y = 0
     else:
         x = asarray(x)
-        y = numpy.zeros(x.shape,x.typecode())
+        y = numpy.zeros(x.shape,x.dtype)
     for i in range(len(p)):
         y = x * y + p[i]
     return y


### PR DESCRIPTION
I pulled in changes by running `git apply <(cd ../gnuradio; git diff v3.7.9 v3.7.9.1 -- gnuradio-runtime)` and bumped `VERSION_INFO_MAINT_VERSION` in CMakeLists.txt.

Hopefully that's the right way to do this? (Might be worth writing down how to do this.) Seems to build correctly, and after I install, my gnuradio installation still seems to work.
